### PR TITLE
Update implementation status with iOS Safari extension polyfill

### DIFF
--- a/implementation-status.md
+++ b/implementation-status.md
@@ -124,6 +124,8 @@ Not supported and no plan to support it in the near future:
 - https://webkit.org/tracking-prevention/#anti-fingerprinting
 - https://bugs.webkit.org/show_bug.cgi?id=101034
 
+Note: on iOS and iPadOS, Web Bluetooth can be polyfilled inside Safari itself via the [iOSWebBLE](https://ioswebble.com) Safari extension, which bridges `navigator.bluetooth` to CoreBluetooth through a `SafariWebExtensionHandler` native process. This is a userland extension, not native WebKit support.
+
 # Node.js
 Node.js ports are available:
 - https://github.com/thegecko/webbluetooth


### PR DESCRIPTION
This pull request updates the implementation-status document to note that Web Bluetooth can be polyfilled on iOS and iPadOS. It adds a reference under the Safari section for iOSWebBLE

The text clarifies that this is a userland extension and not native WebKit support.

(Disclosure: I maintain the iOSWebBLE project. Please let me know if the wording or placement needs adjustment.)