### PR TITLE
Add BluetoothRemoteGATTServer.maxWriteWithoutResponseSize

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3479,6 +3479,7 @@ peripheral's service.
     Promise<BluetoothRemoteGATTDescriptor> getDescriptor(BluetoothDescriptorUUID descriptor);
     Promise<sequence<BluetoothRemoteGATTDescriptor>>
       getDescriptors(optional BluetoothDescriptorUUID descriptor);
+    Promise<unsigned short> getMTU();
     Promise<DataView> readValue();
     Promise<undefined> writeValue(BufferSource value);
     Promise<undefined> writeValueWithResponse(BufferSource value);
@@ -3622,6 +3623,38 @@ getDescriptors(<var>descriptor</var>)</dfn></code> method retrieves a list of
 >   <i>uuid</i>=<code><var>descriptor</var></code>,<br>
 >   <i>allowedUuids</i>=<code>undefined</code>,<br>
 >   <i>child type</i>="GATT Descriptor")</span>
+</div>
+
+<div algorithm="BluetoothRemoteGATTCharacteristic getMTU()">
+The <code><dfn method for="BluetoothRemoteGATTCharacteristic">getMTU()</dfn>
+</code> method exposes the ATT_MTU that bounds the payload of outgoing PDUs
+to the peer on the connection containing this characteristic. When invoked, it
+MUST run the following steps:
+
+1. Let |global| be [=this=]'s [=relevant global object=].
+1. Let |gatt| be [=this=].{{BluetoothRemoteGATTCharacteristic/service}}.{{BluetoothRemoteGATTService/device}}.{{BluetoothDevice/gatt}}.
+1. If |gatt|.{{BluetoothRemoteGATTServer/connected}}
+    is `false`, return [=a promise rejected with=] a "{{NetworkError}}"
+    {{DOMException}} and abort these steps.
+1. Let |characteristic| be [=this=].{{[[representedCharacteristic]]}}.
+1. If |characteristic| is `null`, return [=a promise rejected with=] an
+    "{{InvalidStateError}}" {{DOMException}} and abort these steps.
+1. Return a |gatt|-[=connection-checking wrapper=] around [=a new promise=]
+    |promise| and run the following steps [=in parallel=]:
+    1. Let |mtu| be the ATT_MTU negotiated for the [=ATT Bearer=] that
+        carries |characteristic|, as established by the [=Exchange MTU=]
+        procedure. This is the smaller of the local Host's transmit ATT_MTU
+        and the peer's receive ATT_MTU.
+
+        Note: When no MTU exchange has occurred, |mtu| is the default
+        ATT_MTU of 23 octets.
+    1. [=Queue a global task=] on the [=Bluetooth task source=] given
+        |global| to perform the following steps:
+        1. If |promise| is not in |gatt|.{{[[activeAlgorithms]]}}, [=reject=]
+            |promise| with a "{{NetworkError}}" {{DOMException}} and abort
+            these steps.
+        1. [=Resolve=] |promise| with |mtu|.
+
 </div>
 
 <div algorithm="BluetoothRemoteGATTCharacteristic readValue()">

--- a/index.bs
+++ b/index.bs
@@ -3059,11 +3059,12 @@ creates and caches new objects.
 
 <xmp class="idl">
 [Exposed=Window, SecureContext]
-interface BluetoothRemoteGATTServer {
+interface BluetoothRemoteGATTServer : EventTarget {
   [SameObject]
   readonly attribute BluetoothDevice device;
   readonly attribute boolean connected;
   readonly attribute unsigned short maxWriteWithoutResponseSize;
+  attribute EventHandler onmaxwritewithoutresponsesizechanged;
   Promise<BluetoothRemoteGATTServer> connect();
   undefined disconnect();
   Promise<BluetoothRemoteGATTService> getPrimaryService(BluetoothServiceUUID service);
@@ -3092,12 +3093,12 @@ an [=Exchange MTU=] procedure completes after service discovery. On some
 platforms an updated value can arrive late, after services are resolved.
 Whenever the UA observes that the ATT_MTU has changed it updates this value and
 [=fires an event=] named {{maxwritewithoutresponsesizechanged}} at
-<code>this.device</code>, so the two stay in sync: the value never changes
-without the event firing. Some platforms do not surface ATT_MTU changes to the
-UA at all; on those platforms the value stays constant after it is first
-established and the event never fires. Applications that batch large transfers
-can listen for {{maxwritewithoutresponsesizechanged}} to react to an increase
-instead of re-reading the attribute on every write.
+<code>this</code>, so the two stay in sync: the value never changes without the
+event firing. Some platforms do not surface ATT_MTU changes to the UA at all;
+on those platforms the value stays constant after it is first established and
+the event never fires. Applications that batch large transfers can listen for
+{{maxwritewithoutresponsesizechanged}} to react to an increase instead of
+re-reading the attribute on every write.
 </div>
 
 When no ECMAScript code can
@@ -4411,13 +4412,13 @@ interface <a>participate in a tree</a>.
   </dd>
 
   <dt>
-    <dfn event for="BluetoothDeviceEventHandlers">
+    <dfn event for="BluetoothRemoteGATTServer">
       <code>maxwritewithoutresponsesizechanged</code>
     </dfn>
   </dt>
   <dd>
-    Fired on a {{BluetoothDevice}} when its
-    <code>gatt</code>.{{BluetoothRemoteGATTServer/maxWriteWithoutResponseSize}}
+    Fired on a {{BluetoothRemoteGATTServer}} when its
+    {{BluetoothRemoteGATTServer/maxWriteWithoutResponseSize}}
     <a href="#mtu-change-events">changes</a>, for example after an
     [=Exchange MTU=] procedure renegotiates the ATT_MTU for the connection.
     The UA fires this event whenever it updates the value, so platforms that
@@ -4571,22 +4572,20 @@ never fires.
     1. Let <var>deviceObj</var> be the {{BluetoothDevice}} in the
         <a>Bluetooth tree</a> rooted at <var>bluetoothGlobal</var> that
         represents the remote device.
-    1. If <code><var>deviceObj</var>
-        .gatt.{{BluetoothRemoteGATTServer/connected}}</code>
-        is `false`, abort these sub-steps.
-    1. If <code><var>deviceObj</var>
-        .gatt.{{[[maxWriteWithoutResponseSize]]}}</code> equals
-        <var>newSize</var>, abort these sub-steps.
-    1. Set <code><var>deviceObj</var>
-        .gatt.{{[[maxWriteWithoutResponseSize]]}}</code> to <var>newSize</var>.
-    1. <a>Fire an event</a> named {{maxwritewithoutresponsesizechanged}} with
-        its <code>bubbles</code> attribute initialized to <code>true</code> at
-        <var>deviceObj</var>.
+    1. Let <var>serverObj</var> be <code><var>deviceObj</var>.gatt</code>.
+    1. If <code><var>serverObj</var>
+        .{{BluetoothRemoteGATTServer/connected}}</code> is `false`, abort these
+        sub-steps.
+    1. If <code><var>serverObj</var>
+        .{{[[maxWriteWithoutResponseSize]]}}</code> equals <var>newSize</var>,
+        abort these sub-steps.
+    1. Set <code><var>serverObj</var>
+        .{{[[maxWriteWithoutResponseSize]]}}</code> to <var>newSize</var>.
+    1. <a>Fire an event</a> named {{maxwritewithoutresponsesizechanged}} at
+        <var>serverObj</var>.
 
-        Note: This event is <em>not</em> fired at the
-        {{BluetoothRemoteGATTServer}}. The new value is not carried on the
-        event. Listeners read
-        <code><var>deviceObj</var>.gatt.{{BluetoothRemoteGATTServer/maxWriteWithoutResponseSize}}</code>
+        Note: The new value is not carried on the event. Listeners read
+        <code><var>serverObj</var>.{{BluetoothRemoteGATTServer/maxWriteWithoutResponseSize}}</code>
         to obtain the current value.
 
 </div>
@@ -4793,7 +4792,6 @@ the {{characteristicvaluechanged}} event type.
   interface mixin BluetoothDeviceEventHandlers {
     attribute EventHandler onadvertisementreceived;
     attribute EventHandler ongattserverdisconnected;
-    attribute EventHandler onmaxwritewithoutresponsesizechanged;
   };
 </xmp>
 
@@ -4805,7 +4803,7 @@ type.
 is an <a>Event handler IDL attribute</a> for the {{gattserverdisconnected}}
 event type.
 
-<dfn attribute for="BluetoothDeviceEventHandlers">
+<dfn attribute for="BluetoothRemoteGATTServer">
 onmaxwritewithoutresponsesizechanged</dfn> is an <a>Event handler IDL
 attribute</a> for the {{maxwritewithoutresponsesizechanged}} event type.
 

--- a/index.bs
+++ b/index.bs
@@ -3516,8 +3516,12 @@ an [=Exchange MTU=] procedure completes after service discovery. On some
 platforms an updated value can arrive late, after services are resolved.
 Applications SHOULD read
 {{BluetoothRemoteGATTCharacteristic/maxWriteWithoutResponseSize}} each time it
-is needed rather than caching it. To be notified when it changes, listen for
-the {{maxwritewithoutresponsesizechanged}} event.
+is needed rather than caching it. The {{maxwritewithoutresponsesizechanged}}
+event is provided as a best-effort notification, but it is not guaranteed to
+fire on every platform: some operating systems do not expose a notification
+when the ATT_MTU changes. Applications MUST NOT rely on the event as the only
+way to observe the current value, and SHOULD treat it purely as a hint to
+re-read the attribute.
 </div>
 
 Instances of {{BluetoothRemoteGATTCharacteristic}} are created with the
@@ -4405,6 +4409,8 @@ interface <a>participate in a tree</a>.
     {{BluetoothRemoteGATTCharacteristic/maxWriteWithoutResponseSize}}
     <a href="#mtu-change-events">changes</a>, for example after an
     [=Exchange MTU=] procedure renegotiates the ATT_MTU for the connection.
+    This event is best-effort: it is not guaranteed to fire on platforms
+    that do not surface ATT_MTU changes to the UA.
   </dd>
 
   <dt>
@@ -4535,6 +4541,13 @@ When the ATT_MTU negotiated for an [=ATT Bearer=] changes, for example because
 the UA receives the result of an [=Exchange MTU=] procedure, the UA must
 perform the following steps for each <a>Characteristic</a>
 <var>characteristic</var> carried by that [=ATT Bearer=]:
+
+Note: These steps fire the {{maxwritewithoutresponsesizechanged}} event on a
+best-effort basis. Some platforms do not notify the UA when the ATT_MTU
+changes, in which case the event does not fire even though
+{{BluetoothRemoteGATTCharacteristic/maxWriteWithoutResponseSize}} may return a
+different value on a subsequent read. The event is therefore a hint to
+re-read the attribute, not an authoritative signal.
 
 1. For each |bluetoothGlobal| whose [=Bluetooth tree=] contains a
     {{BluetoothRemoteGATTCharacteristic}} representing <var>characteristic</var>,

--- a/index.bs
+++ b/index.bs
@@ -3516,7 +3516,8 @@ an [=Exchange MTU=] procedure completes after [=service discovery=]. On some
 platforms an updated value can arrive late, after services are resolved.
 Applications SHOULD read
 {{BluetoothRemoteGATTCharacteristic/maxWriteWithoutResponseSize}} each time it
-is needed rather than caching it.
+is needed rather than caching it. To be notified when it changes, listen for
+the {{maxwritewithoutresponsesizechanged}} event.
 </div>
 
 Instances of {{BluetoothRemoteGATTCharacteristic}} are created with the
@@ -4396,6 +4397,18 @@ interface <a>participate in a tree</a>.
   </dd>
 
   <dt>
+    <dfn event for="BluetoothRemoteGATTCharacteristic">
+      <code>maxwritewithoutresponsesizechanged</code>
+    </dfn>
+  </dt>
+  <dd>
+    Fired on a {{BluetoothRemoteGATTCharacteristic}} when its
+    {{BluetoothRemoteGATTCharacteristic/maxWriteWithoutResponseSize}}
+    <a href="#mtu-change-events">changes</a>, for example after an
+    [=Exchange MTU=] procedure renegotiates the ATT_MTU for the connection.
+  </dd>
+
+  <dt>
     <dfn event for="BluetoothRemoteGATTService"><code>serviceadded</code></dfn>
   </dt>
   <dd>
@@ -4513,6 +4526,36 @@ it must perform the following steps:
     1. <a>Fire an event</a> named {{characteristicvaluechanged}} with its
         <code>bubbles</code> attribute initialized to <code>true</code> at
         <var>characteristicObject</var>.
+
+</div>
+
+### Responding to MTU Changes ### {#mtu-change-events}
+
+<div algorithm="mtu changes">
+When the ATT_MTU negotiated for an [=ATT Bearer=] changes, for example because
+the UA receives the result of an [=Exchange MTU=] procedure, the UA must
+perform the following steps for each <a>Characteristic</a> carried by that
+[=ATT Bearer=]:
+
+1. For each |bluetoothGlobal| whose [=Bluetooth tree=] contains a
+    {{BluetoothRemoteGATTCharacteristic}} representing the <a>Characteristic</a>,
+    [=queue a global task=] on the [=Bluetooth task source=] given
+    |bluetoothGlobal|'s [=relevant global object=] to do the following
+    sub-steps:
+    1. Let <var>characteristicObject</var> be the
+        {{BluetoothRemoteGATTCharacteristic}} in the <a>Bluetooth tree</a>
+        rooted at <var>bluetoothGlobal</var> that represents the
+        <a>Characteristic</a>.
+    1. If <code><var>characteristicObject</var>
+        .service.device.gatt.{{BluetoothRemoteGATTServer/connected}}</code>
+        is `false`, abort these sub-steps.
+    1. <a>Fire an event</a> named {{maxwritewithoutresponsesizechanged}} with
+        its <code>bubbles</code> attribute initialized to <code>true</code> at
+        <var>characteristicObject</var>.
+
+        Note: The new value is not carried on the event. Listeners read
+        <var>characteristicObject</var>.{{BluetoothRemoteGATTCharacteristic/maxWriteWithoutResponseSize}}
+        to obtain the current value.
 
 </div>
 
@@ -4706,12 +4749,17 @@ Changed characteristic, it MUST perform the following steps.
   [SecureContext]
   interface mixin CharacteristicEventHandlers {
     attribute EventHandler oncharacteristicvaluechanged;
+    attribute EventHandler onmaxwritewithoutresponsesizechanged;
   };
 </xmp>
 
 <dfn attribute for="CharacteristicEventHandlers">
 oncharacteristicvaluechanged</dfn> is an <a>Event handler IDL attribute</a> for
 the {{characteristicvaluechanged}} event type.
+
+<dfn attribute for="CharacteristicEventHandlers">
+onmaxwritewithoutresponsesizechanged</dfn> is an <a>Event handler IDL
+attribute</a> for the {{maxwritewithoutresponsesizechanged}} event type.
 
 <xmp class="idl">
   [SecureContext]

--- a/index.bs
+++ b/index.bs
@@ -3063,6 +3063,7 @@ interface BluetoothRemoteGATTServer {
   [SameObject]
   readonly attribute BluetoothDevice device;
   readonly attribute boolean connected;
+  readonly attribute unsigned short maxWriteWithoutResponseSize;
   Promise<BluetoothRemoteGATTServer> connect();
   undefined disconnect();
   Promise<BluetoothRemoteGATTService> getPrimaryService(BluetoothServiceUUID service);
@@ -3079,6 +3080,24 @@ interface BluetoothRemoteGATTServer {
 <code>this.device</code>. It can be false while the UA is physically connected,
 for example when there are other connected {{BluetoothRemoteGATTServer}}
 instances for other <a>global object</a>s.
+
+<dfn>maxWriteWithoutResponseSize</dfn> is the largest [=byte sequence=], in
+octets, that {{BluetoothRemoteGATTCharacteristic/writeValueWithoutResponse()}}
+can send to the peer in a single ATT PDU without it being fragmented or
+rejected. It is derived from the ATT_MTU negotiated for the connection to
+<code>this.device</code>.
+
+Note: This value can change while the device is connected, for example because
+an [=Exchange MTU=] procedure completes after service discovery. On some
+platforms an updated value can arrive late, after services are resolved.
+Whenever the UA observes that the ATT_MTU has changed it updates this value and
+[=fires an event=] named {{maxwritewithoutresponsesizechanged}} at
+<code>this.device</code>, so the two stay in sync: the value never changes
+without the event firing. Some platforms do not surface ATT_MTU changes to the
+UA at all; on those platforms the value stays constant after it is first
+established and the event never fires. Applications that batch large transfers
+can listen for {{maxwritewithoutresponsesizechanged}} to react to an increase
+instead of re-reading the attribute on every write.
 </div>
 
 When no ECMAScript code can
@@ -3122,7 +3141,36 @@ slots</a> described in the following table:
       The simulated GATT connection response code for a GATT connection attempt.
     </td>
   </tr>
+  <tr>
+    <td><dfn>\[[maxWriteWithoutResponseSize]]</dfn></td>
+    <td><code>20</code></td>
+    <td>
+      The value, in octets, exposed by
+      {{BluetoothRemoteGATTServer/maxWriteWithoutResponseSize}}. It is
+      established when a connection to
+      {{BluetoothRemoteGATTServer/device}}.{{[[representedDevice]]}} is made and
+      updated only when the UA learns of an ATT_MTU change for that connection,
+      at which point the {{maxwritewithoutresponsesizechanged}} event is fired.
+      The initial value of <code>20</code> corresponds to the default ATT_MTU of
+      23 octets minus the 3-octet ATT Write Command header.
+    </td>
+  </tr>
 </table>
+
+<div algorithm="BluetoothRemoteGATTServer maxWriteWithoutResponseSize">
+The {{BluetoothRemoteGATTServer/maxWriteWithoutResponseSize}} getter steps are:
+
+1. Return [=this=].{{[[maxWriteWithoutResponseSize]]}}.
+
+<div class="note">
+Note: The stored value is the ATT_MTU negotiated for the connection to the
+remote device, minus 3 octets. The 3 octets account for the ATT Write Command
+header (1 octet opcode and 2 octet attribute handle), leaving the space
+available for the attribute value in a single PDU. The value is established
+when the connection is made and only changes when the UA observes an ATT_MTU
+change; see [[#mtu-change-events]].
+</div>
+</div>
 
 <div algorithm="BluetoothRemoteGATTServer connect">
 The <code><dfn method for="BluetoothRemoteGATTServer">connect()</dfn></code>
@@ -3476,7 +3524,6 @@ peripheral's service.
     readonly attribute UUID uuid;
     readonly attribute BluetoothCharacteristicProperties properties;
     readonly attribute DataView? value;
-    readonly attribute unsigned short maxWriteWithoutResponseSize;
     Promise<BluetoothRemoteGATTDescriptor> getDescriptor(BluetoothDescriptorUUID descriptor);
     Promise<sequence<BluetoothRemoteGATTDescriptor>>
       getDescriptors(optional BluetoothDescriptorUUID descriptor);
@@ -3504,24 +3551,6 @@ Heart Rate Measurement</a> characteristic.
 <dfn>value</dfn> is the currently cached characteristic value. This value gets
 updated when the value of the characteristic is read or updated via a
 notification or indication.
-
-<dfn>maxWriteWithoutResponseSize</dfn> is the largest [=byte sequence=], in
-octets, that {{BluetoothRemoteGATTCharacteristic/writeValueWithoutResponse()}}
-can send to the peer in a single ATT PDU without it being fragmented or
-rejected. It is derived from the ATT_MTU negotiated for the connection that
-carries this characteristic.
-
-Note: This value can change while the device is connected, for example because
-an [=Exchange MTU=] procedure completes after service discovery. On some
-platforms an updated value can arrive late, after services are resolved.
-Whenever the UA observes that the ATT_MTU has changed it updates this value and
-[=fires an event=] named {{maxwritewithoutresponsesizechanged}}, so the two stay
-in sync: the value never changes without the event firing. Some platforms do
-not surface ATT_MTU changes to the UA at all; on those platforms the value
-stays constant after it is first established and the event never fires.
-Applications that batch large transfers can listen for
-{{maxwritewithoutresponsesizechanged}} to react to an increase instead of
-re-reading the attribute on every write.
 </div>
 
 Instances of {{BluetoothRemoteGATTCharacteristic}} are created with the
@@ -3539,20 +3568,6 @@ Instances of {{BluetoothRemoteGATTCharacteristic}} are created with the
     <td>
       The <a>Characteristic</a> this object represents, or `null` if the
       Characteristic has been removed or otherwise invalidated.
-    </td>
-  </tr>
-  <tr>
-    <td><dfn>\[[maxWriteWithoutResponseSize]]</dfn></td>
-    <td><code>20</code></td>
-    <td>
-      The value, in octets, exposed by
-      {{BluetoothRemoteGATTCharacteristic/maxWriteWithoutResponseSize}}. It is
-      established when the {{[[representedCharacteristic]]}} is discovered and
-      updated only when the UA learns of an ATT_MTU change for the
-      [=ATT Bearer=] that carries it, at which point the
-      {{maxwritewithoutresponsesizechanged}} event is fired. The initial value
-      of <code>20</code> corresponds to the default ATT_MTU of 23 octets minus
-      the 3-octet ATT Write Command header.
     </td>
   </tr>
   <tr>
@@ -3655,22 +3670,6 @@ getDescriptors(<var>descriptor</var>)</dfn></code> method retrieves a list of
 >   <i>uuid</i>=<code><var>descriptor</var></code>,<br>
 >   <i>allowedUuids</i>=<code>undefined</code>,<br>
 >   <i>child type</i>="GATT Descriptor")</span>
-</div>
-
-<div algorithm="BluetoothRemoteGATTCharacteristic maxWriteWithoutResponseSize">
-The {{BluetoothRemoteGATTCharacteristic/maxWriteWithoutResponseSize}} getter
-steps are:
-
-1. Return [=this=].{{[[maxWriteWithoutResponseSize]]}}.
-
-<div class="note">
-Note: The stored value is the ATT_MTU negotiated for the [=ATT Bearer=] that
-carries the characteristic, minus 3 octets. The 3 octets account for the ATT
-Write Command header (1 octet opcode and 2 octet attribute handle), leaving the
-space available for the attribute value in a single PDU. The value is
-established when the characteristic is discovered and only changes when the UA
-observes an ATT_MTU change; see [[#mtu-change-events]].
-</div>
 </div>
 
 <div algorithm="BluetoothRemoteGATTCharacteristic readValue()">
@@ -4412,13 +4411,13 @@ interface <a>participate in a tree</a>.
   </dd>
 
   <dt>
-    <dfn event for="BluetoothRemoteGATTCharacteristic">
+    <dfn event for="BluetoothDeviceEventHandlers">
       <code>maxwritewithoutresponsesizechanged</code>
     </dfn>
   </dt>
   <dd>
-    Fired on a {{BluetoothRemoteGATTCharacteristic}} when its
-    {{BluetoothRemoteGATTCharacteristic/maxWriteWithoutResponseSize}}
+    Fired on a {{BluetoothDevice}} when its
+    <code>gatt</code>.{{BluetoothRemoteGATTServer/maxWriteWithoutResponseSize}}
     <a href="#mtu-change-events">changes</a>, for example after an
     [=Exchange MTU=] procedure renegotiates the ATT_MTU for the connection.
     The UA fires this event whenever it updates the value, so platforms that
@@ -4550,10 +4549,9 @@ it must perform the following steps:
 ### Responding to MTU Changes ### {#mtu-change-events}
 
 <div algorithm="mtu changes">
-When the ATT_MTU negotiated for an [=ATT Bearer=] changes, for example because
-the UA receives the result of an [=Exchange MTU=] procedure, the UA must
-perform the following steps for each <a>Characteristic</a>
-<var>characteristic</var> carried by that [=ATT Bearer=]:
+When the ATT_MTU negotiated for the connection to a remote device changes, for
+example because the UA receives the result of an [=Exchange MTU=] procedure,
+the UA must perform the following steps:
 
 Note: The UA only runs these steps when it observes an ATT_MTU change. Updating
 the stored value and firing the {{maxwritewithoutresponsesizechanged}} event
@@ -4562,32 +4560,33 @@ that do not surface ATT_MTU changes to the UA never run these steps, so on those
 platforms the value stays constant after it is first established and the event
 never fires.
 
-1. Let <var>newSize</var> be the ATT_MTU now negotiated for that
-    [=ATT Bearer=] &minus; 3. This is the smaller of the local Host's transmit
-    ATT_MTU and the peer's receive ATT_MTU, less the 3-octet ATT Write Command
-    header.
+1. Let <var>newSize</var> be the ATT_MTU now negotiated for the connection
+    &minus; 3. This is the smaller of the local Host's transmit ATT_MTU and the
+    peer's receive ATT_MTU, less the 3-octet ATT Write Command header.
 1. For each |bluetoothGlobal| whose [=Bluetooth tree=] contains a
-    {{BluetoothRemoteGATTCharacteristic}} representing <var>characteristic</var>,
+    {{BluetoothDevice}} representing the remote device,
     [=queue a global task=] on the [=Bluetooth task source=] given
     |bluetoothGlobal|'s [=relevant global object=] to do the following
     sub-steps:
-    1. Let <var>characteristicObject</var> be the
-        {{BluetoothRemoteGATTCharacteristic}} in the <a>Bluetooth tree</a>
-        rooted at <var>bluetoothGlobal</var> that represents
-        <var>characteristic</var>.
-    1. If <code><var>characteristicObject</var>
-        .service.device.gatt.{{BluetoothRemoteGATTServer/connected}}</code>
+    1. Let <var>deviceObj</var> be the {{BluetoothDevice}} in the
+        <a>Bluetooth tree</a> rooted at <var>bluetoothGlobal</var> that
+        represents the remote device.
+    1. If <code><var>deviceObj</var>
+        .gatt.{{BluetoothRemoteGATTServer/connected}}</code>
         is `false`, abort these sub-steps.
-    1. If <var>characteristicObject</var>.{{[[maxWriteWithoutResponseSize]]}}
-        equals <var>newSize</var>, abort these sub-steps.
-    1. Set <var>characteristicObject</var>.{{[[maxWriteWithoutResponseSize]]}}
-        to <var>newSize</var>.
+    1. If <code><var>deviceObj</var>
+        .gatt.{{[[maxWriteWithoutResponseSize]]}}</code> equals
+        <var>newSize</var>, abort these sub-steps.
+    1. Set <code><var>deviceObj</var>
+        .gatt.{{[[maxWriteWithoutResponseSize]]}}</code> to <var>newSize</var>.
     1. <a>Fire an event</a> named {{maxwritewithoutresponsesizechanged}} with
         its <code>bubbles</code> attribute initialized to <code>true</code> at
-        <var>characteristicObject</var>.
+        <var>deviceObj</var>.
 
-        Note: The new value is not carried on the event. Listeners read
-        <var>characteristicObject</var>.{{BluetoothRemoteGATTCharacteristic/maxWriteWithoutResponseSize}}
+        Note: This event is <em>not</em> fired at the
+        {{BluetoothRemoteGATTServer}}. The new value is not carried on the
+        event. Listeners read
+        <code><var>deviceObj</var>.gatt.{{BluetoothRemoteGATTServer/maxWriteWithoutResponseSize}}</code>
         to obtain the current value.
 
 </div>
@@ -4782,7 +4781,6 @@ Changed characteristic, it MUST perform the following steps.
   [SecureContext]
   interface mixin CharacteristicEventHandlers {
     attribute EventHandler oncharacteristicvaluechanged;
-    attribute EventHandler onmaxwritewithoutresponsesizechanged;
   };
 </xmp>
 
@@ -4790,15 +4788,12 @@ Changed characteristic, it MUST perform the following steps.
 oncharacteristicvaluechanged</dfn> is an <a>Event handler IDL attribute</a> for
 the {{characteristicvaluechanged}} event type.
 
-<dfn attribute for="CharacteristicEventHandlers">
-onmaxwritewithoutresponsesizechanged</dfn> is an <a>Event handler IDL
-attribute</a> for the {{maxwritewithoutresponsesizechanged}} event type.
-
 <xmp class="idl">
   [SecureContext]
   interface mixin BluetoothDeviceEventHandlers {
     attribute EventHandler onadvertisementreceived;
     attribute EventHandler ongattserverdisconnected;
+    attribute EventHandler onmaxwritewithoutresponsesizechanged;
   };
 </xmp>
 
@@ -4809,6 +4804,10 @@ type.
 <dfn attribute for="BluetoothDeviceEventHandlers">ongattserverdisconnected</dfn>
 is an <a>Event handler IDL attribute</a> for the {{gattserverdisconnected}}
 event type.
+
+<dfn attribute for="BluetoothDeviceEventHandlers">
+onmaxwritewithoutresponsesizechanged</dfn> is an <a>Event handler IDL
+attribute</a> for the {{maxwritewithoutresponsesizechanged}} event type.
 
 <xmp class="idl">
   [SecureContext]

--- a/index.bs
+++ b/index.bs
@@ -4533,18 +4533,18 @@ it must perform the following steps:
 <div algorithm="mtu changes">
 When the ATT_MTU negotiated for an [=ATT Bearer=] changes, for example because
 the UA receives the result of an [=Exchange MTU=] procedure, the UA must
-perform the following steps for each <a>Characteristic</a> carried by that
-[=ATT Bearer=]:
+perform the following steps for each <a>Characteristic</a>
+<var>characteristic</var> carried by that [=ATT Bearer=]:
 
 1. For each |bluetoothGlobal| whose [=Bluetooth tree=] contains a
-    {{BluetoothRemoteGATTCharacteristic}} representing the <a>Characteristic</a>,
+    {{BluetoothRemoteGATTCharacteristic}} representing <var>characteristic</var>,
     [=queue a global task=] on the [=Bluetooth task source=] given
     |bluetoothGlobal|'s [=relevant global object=] to do the following
     sub-steps:
     1. Let <var>characteristicObject</var> be the
         {{BluetoothRemoteGATTCharacteristic}} in the <a>Bluetooth tree</a>
-        rooted at <var>bluetoothGlobal</var> that represents the
-        <a>Characteristic</a>.
+        rooted at <var>bluetoothGlobal</var> that represents
+        <var>characteristic</var>.
     1. If <code><var>characteristicObject</var>
         .service.device.gatt.{{BluetoothRemoteGATTServer/connected}}</code>
         is `false`, abort these sub-steps.

--- a/index.bs
+++ b/index.bs
@@ -3514,15 +3514,14 @@ carries this characteristic.
 Note: This value can change while the device is connected, for example because
 an [=Exchange MTU=] procedure completes after service discovery. On some
 platforms an updated value can arrive late, after services are resolved.
-Reading
-{{BluetoothRemoteGATTCharacteristic/maxWriteWithoutResponseSize}} always
-returns the current value, so applications SHOULD read it each time it is
-needed rather than caching it in a variable. As a convenience, the UA also
-[=fires an event=] named {{maxwritewithoutresponsesizechanged}} when it
-observes a change, so applications that batch large transfers can react to an
-increase instead of polling. Not every platform surfaces ATT_MTU changes, so
-the event is not guaranteed to fire; the attribute remains the authoritative
-source and a fresh read returns the current value regardless.
+Whenever the UA observes that the ATT_MTU has changed it updates this value and
+[=fires an event=] named {{maxwritewithoutresponsesizechanged}}, so the two stay
+in sync: the value never changes without the event firing. Some platforms do
+not surface ATT_MTU changes to the UA at all; on those platforms the value
+stays constant after it is first established and the event never fires.
+Applications that batch large transfers can listen for
+{{maxwritewithoutresponsesizechanged}} to react to an increase instead of
+re-reading the attribute on every write.
 </div>
 
 Instances of {{BluetoothRemoteGATTCharacteristic}} are created with the
@@ -3540,6 +3539,20 @@ Instances of {{BluetoothRemoteGATTCharacteristic}} are created with the
     <td>
       The <a>Characteristic</a> this object represents, or `null` if the
       Characteristic has been removed or otherwise invalidated.
+    </td>
+  </tr>
+  <tr>
+    <td><dfn>\[[maxWriteWithoutResponseSize]]</dfn></td>
+    <td><code>20</code></td>
+    <td>
+      The value, in octets, exposed by
+      {{BluetoothRemoteGATTCharacteristic/maxWriteWithoutResponseSize}}. It is
+      established when the {{[[representedCharacteristic]]}} is discovered and
+      updated only when the UA learns of an ATT_MTU change for the
+      [=ATT Bearer=] that carries it, at which point the
+      {{maxwritewithoutresponsesizechanged}} event is fired. The initial value
+      of <code>20</code> corresponds to the default ATT_MTU of 23 octets minus
+      the 3-octet ATT Write Command header.
     </td>
   </tr>
   <tr>
@@ -3648,20 +3661,15 @@ getDescriptors(<var>descriptor</var>)</dfn></code> method retrieves a list of
 The {{BluetoothRemoteGATTCharacteristic/maxWriteWithoutResponseSize}} getter
 steps are:
 
-1. Let |mtu| be the ATT_MTU currently negotiated for the [=ATT Bearer=] that
-    carries [=this=].{{[[representedCharacteristic]]}}, as established by the
-    [=Exchange MTU=] procedure. This is the smaller of the local Host's
-    transmit ATT_MTU and the peer's receive ATT_MTU. When no MTU exchange has
-    occurred, |mtu| is the default ATT_MTU of 23 octets.
-1. Return |mtu| &minus; 3.
+1. Return [=this=].{{[[maxWriteWithoutResponseSize]]}}.
 
 <div class="note">
-Note: The getter reflects the ATT_MTU at the time it is read, so a fresh read
-always returns the current value even on platforms that do not surface
-ATT_MTU changes via the {{maxwritewithoutresponsesizechanged}} event.
-3 octets are subtracted to account for the ATT Write Command header (1 octet
-opcode and 2 octet attribute handle), leaving the space available for the
-attribute value in a single PDU.
+Note: The stored value is the ATT_MTU negotiated for the [=ATT Bearer=] that
+carries the characteristic, minus 3 octets. The 3 octets account for the ATT
+Write Command header (1 octet opcode and 2 octet attribute handle), leaving the
+space available for the attribute value in a single PDU. The value is
+established when the characteristic is discovered and only changes when the UA
+observes an ATT_MTU change; see [[#mtu-change-events]].
 </div>
 </div>
 
@@ -4413,9 +4421,9 @@ interface <a>participate in a tree</a>.
     {{BluetoothRemoteGATTCharacteristic/maxWriteWithoutResponseSize}}
     <a href="#mtu-change-events">changes</a>, for example after an
     [=Exchange MTU=] procedure renegotiates the ATT_MTU for the connection.
-    The UA fires this event when it observes such a change. Platforms that do
-    not surface ATT_MTU changes do not fire this event, but reading the
-    attribute still returns the current value.
+    The UA fires this event whenever it updates the value, so platforms that
+    never surface ATT_MTU changes (and therefore never change the value) also
+    never fire this event.
   </dd>
 
   <dt>
@@ -4547,13 +4555,17 @@ the UA receives the result of an [=Exchange MTU=] procedure, the UA must
 perform the following steps for each <a>Characteristic</a>
 <var>characteristic</var> carried by that [=ATT Bearer=]:
 
-Note: This event is a convenience notification. The
-{{BluetoothRemoteGATTCharacteristic/maxWriteWithoutResponseSize}} getter always
-reflects the current ATT_MTU when read, so reading it after a change returns the
-new value whether or not this event fires. Platforms that do not surface
-ATT_MTU changes to the UA never run these steps and so never fire the event,
-but a fresh read of the attribute still returns the current value.
+Note: The UA only runs these steps when it observes an ATT_MTU change. Updating
+the stored value and firing the {{maxwritewithoutresponsesizechanged}} event
+happen together, so the value never changes without the event firing. Platforms
+that do not surface ATT_MTU changes to the UA never run these steps, so on those
+platforms the value stays constant after it is first established and the event
+never fires.
 
+1. Let <var>newSize</var> be the ATT_MTU now negotiated for that
+    [=ATT Bearer=] &minus; 3. This is the smaller of the local Host's transmit
+    ATT_MTU and the peer's receive ATT_MTU, less the 3-octet ATT Write Command
+    header.
 1. For each |bluetoothGlobal| whose [=Bluetooth tree=] contains a
     {{BluetoothRemoteGATTCharacteristic}} representing <var>characteristic</var>,
     [=queue a global task=] on the [=Bluetooth task source=] given
@@ -4566,6 +4578,10 @@ but a fresh read of the attribute still returns the current value.
     1. If <code><var>characteristicObject</var>
         .service.device.gatt.{{BluetoothRemoteGATTServer/connected}}</code>
         is `false`, abort these sub-steps.
+    1. If <var>characteristicObject</var>.{{[[maxWriteWithoutResponseSize]]}}
+        equals <var>newSize</var>, abort these sub-steps.
+    1. Set <var>characteristicObject</var>.{{[[maxWriteWithoutResponseSize]]}}
+        to <var>newSize</var>.
     1. <a>Fire an event</a> named {{maxwritewithoutresponsesizechanged}} with
         its <code>bubbles</code> attribute initialized to <code>true</code> at
         <var>characteristicObject</var>.

--- a/index.bs
+++ b/index.bs
@@ -3476,10 +3476,10 @@ peripheral's service.
     readonly attribute UUID uuid;
     readonly attribute BluetoothCharacteristicProperties properties;
     readonly attribute DataView? value;
+    readonly attribute unsigned short maxWriteWithoutResponseSize;
     Promise<BluetoothRemoteGATTDescriptor> getDescriptor(BluetoothDescriptorUUID descriptor);
     Promise<sequence<BluetoothRemoteGATTDescriptor>>
       getDescriptors(optional BluetoothDescriptorUUID descriptor);
-    Promise<unsigned short> getMTU();
     Promise<DataView> readValue();
     Promise<undefined> writeValue(BufferSource value);
     Promise<undefined> writeValueWithResponse(BufferSource value);
@@ -3504,6 +3504,19 @@ Heart Rate Measurement</a> characteristic.
 <dfn>value</dfn> is the currently cached characteristic value. This value gets
 updated when the value of the characteristic is read or updated via a
 notification or indication.
+
+<dfn>maxWriteWithoutResponseSize</dfn> is the largest [=byte sequence=], in
+octets, that {{BluetoothRemoteGATTCharacteristic/writeValueWithoutResponse()}}
+can send to the peer in a single ATT PDU without it being fragmented or
+rejected. It is derived from the ATT_MTU negotiated for the connection that
+carries this characteristic.
+
+Note: This value can change while the device is connected, for example because
+an [=Exchange MTU=] procedure completes after [=service discovery=]. On some
+platforms an updated value can arrive late, after services are resolved.
+Applications SHOULD read
+{{BluetoothRemoteGATTCharacteristic/maxWriteWithoutResponseSize}} each time it
+is needed rather than caching it.
 </div>
 
 Instances of {{BluetoothRemoteGATTCharacteristic}} are created with the
@@ -3625,36 +3638,23 @@ getDescriptors(<var>descriptor</var>)</dfn></code> method retrieves a list of
 >   <i>child type</i>="GATT Descriptor")</span>
 </div>
 
-<div algorithm="BluetoothRemoteGATTCharacteristic getMTU()">
-The <code><dfn method for="BluetoothRemoteGATTCharacteristic">getMTU()</dfn>
-</code> method exposes the ATT_MTU that bounds the payload of outgoing PDUs
-to the peer on the connection containing this characteristic. When invoked, it
-MUST run the following steps:
+<div algorithm="BluetoothRemoteGATTCharacteristic maxWriteWithoutResponseSize">
+The <dfn attribute
+for="BluetoothRemoteGATTCharacteristic">maxWriteWithoutResponseSize</dfn>
+getter steps are:
 
-1. Let |global| be [=this=]'s [=relevant global object=].
-1. Let |gatt| be [=this=].{{BluetoothRemoteGATTCharacteristic/service}}.{{BluetoothRemoteGATTService/device}}.{{BluetoothDevice/gatt}}.
-1. If |gatt|.{{BluetoothRemoteGATTServer/connected}}
-    is `false`, return [=a promise rejected with=] a "{{NetworkError}}"
-    {{DOMException}} and abort these steps.
-1. Let |characteristic| be [=this=].{{[[representedCharacteristic]]}}.
-1. If |characteristic| is `null`, return [=a promise rejected with=] an
-    "{{InvalidStateError}}" {{DOMException}} and abort these steps.
-1. Return a |gatt|-[=connection-checking wrapper=] around [=a new promise=]
-    |promise| and run the following steps [=in parallel=]:
-    1. Let |mtu| be the ATT_MTU negotiated for the [=ATT Bearer=] that
-        carries |characteristic|, as established by the [=Exchange MTU=]
-        procedure. This is the smaller of the local Host's transmit ATT_MTU
-        and the peer's receive ATT_MTU.
+1. Let |mtu| be the ATT_MTU negotiated for the [=ATT Bearer=] that carries
+    [=this=].{{[[representedCharacteristic]]}}, as established by the
+    [=Exchange MTU=] procedure. This is the smaller of the local Host's
+    transmit ATT_MTU and the peer's receive ATT_MTU.
 
-        Note: When no MTU exchange has occurred, |mtu| is the default
-        ATT_MTU of 23 octets.
-    1. [=Queue a global task=] on the [=Bluetooth task source=] given
-        |global| to perform the following steps:
-        1. If |promise| is not in |gatt|.{{[[activeAlgorithms]]}}, [=reject=]
-            |promise| with a "{{NetworkError}}" {{DOMException}} and abort
-            these steps.
-        1. [=Resolve=] |promise| with |mtu|.
+    Note: When no MTU exchange has occurred, |mtu| is the default ATT_MTU of
+    23 octets.
+1. Return |mtu| &minus; 3.
 
+    Note: 3 octets are subtracted to account for the ATT Write Command header
+    (1 octet opcode and 2 octet attribute handle), leaving the space available
+    for the attribute value in a single PDU.
 </div>
 
 <div algorithm="BluetoothRemoteGATTCharacteristic readValue()">

--- a/index.bs
+++ b/index.bs
@@ -3512,7 +3512,7 @@ rejected. It is derived from the ATT_MTU negotiated for the connection that
 carries this characteristic.
 
 Note: This value can change while the device is connected, for example because
-an [=Exchange MTU=] procedure completes after [=service discovery=]. On some
+an [=Exchange MTU=] procedure completes after service discovery. On some
 platforms an updated value can arrive late, after services are resolved.
 Applications SHOULD read
 {{BluetoothRemoteGATTCharacteristic/maxWriteWithoutResponseSize}} each time it
@@ -3640,22 +3640,21 @@ getDescriptors(<var>descriptor</var>)</dfn></code> method retrieves a list of
 </div>
 
 <div algorithm="BluetoothRemoteGATTCharacteristic maxWriteWithoutResponseSize">
-The <dfn attribute
-for="BluetoothRemoteGATTCharacteristic">maxWriteWithoutResponseSize</dfn>
-getter steps are:
+The {{BluetoothRemoteGATTCharacteristic/maxWriteWithoutResponseSize}} getter
+steps are:
 
 1. Let |mtu| be the ATT_MTU negotiated for the [=ATT Bearer=] that carries
     [=this=].{{[[representedCharacteristic]]}}, as established by the
     [=Exchange MTU=] procedure. This is the smaller of the local Host's
-    transmit ATT_MTU and the peer's receive ATT_MTU.
-
-    Note: When no MTU exchange has occurred, |mtu| is the default ATT_MTU of
-    23 octets.
+    transmit ATT_MTU and the peer's receive ATT_MTU. When no MTU exchange has
+    occurred, |mtu| is the default ATT_MTU of 23 octets.
 1. Return |mtu| &minus; 3.
 
-    Note: 3 octets are subtracted to account for the ATT Write Command header
-    (1 octet opcode and 2 octet attribute handle), leaving the space available
-    for the attribute value in a single PDU.
+<div class="note">
+Note: 3 octets are subtracted to account for the ATT Write Command header
+(1 octet opcode and 2 octet attribute handle), leaving the space available
+for the attribute value in a single PDU.
+</div>
 </div>
 
 <div algorithm="BluetoothRemoteGATTCharacteristic readValue()">

--- a/index.bs
+++ b/index.bs
@@ -3514,14 +3514,15 @@ carries this characteristic.
 Note: This value can change while the device is connected, for example because
 an [=Exchange MTU=] procedure completes after service discovery. On some
 platforms an updated value can arrive late, after services are resolved.
-Applications SHOULD read
-{{BluetoothRemoteGATTCharacteristic/maxWriteWithoutResponseSize}} each time it
-is needed rather than caching it. The {{maxwritewithoutresponsesizechanged}}
-event is provided as a best-effort notification, but it is not guaranteed to
-fire on every platform: some operating systems do not expose a notification
-when the ATT_MTU changes. Applications MUST NOT rely on the event as the only
-way to observe the current value, and SHOULD treat it purely as a hint to
-re-read the attribute.
+Reading
+{{BluetoothRemoteGATTCharacteristic/maxWriteWithoutResponseSize}} always
+returns the current value, so applications SHOULD read it each time it is
+needed rather than caching it in a variable. As a convenience, the UA also
+[=fires an event=] named {{maxwritewithoutresponsesizechanged}} when it
+observes a change, so applications that batch large transfers can react to an
+increase instead of polling. Not every platform surfaces ATT_MTU changes, so
+the event is not guaranteed to fire; the attribute remains the authoritative
+source and a fresh read returns the current value regardless.
 </div>
 
 Instances of {{BluetoothRemoteGATTCharacteristic}} are created with the
@@ -3647,17 +3648,20 @@ getDescriptors(<var>descriptor</var>)</dfn></code> method retrieves a list of
 The {{BluetoothRemoteGATTCharacteristic/maxWriteWithoutResponseSize}} getter
 steps are:
 
-1. Let |mtu| be the ATT_MTU negotiated for the [=ATT Bearer=] that carries
-    [=this=].{{[[representedCharacteristic]]}}, as established by the
+1. Let |mtu| be the ATT_MTU currently negotiated for the [=ATT Bearer=] that
+    carries [=this=].{{[[representedCharacteristic]]}}, as established by the
     [=Exchange MTU=] procedure. This is the smaller of the local Host's
     transmit ATT_MTU and the peer's receive ATT_MTU. When no MTU exchange has
     occurred, |mtu| is the default ATT_MTU of 23 octets.
 1. Return |mtu| &minus; 3.
 
 <div class="note">
-Note: 3 octets are subtracted to account for the ATT Write Command header
-(1 octet opcode and 2 octet attribute handle), leaving the space available
-for the attribute value in a single PDU.
+Note: The getter reflects the ATT_MTU at the time it is read, so a fresh read
+always returns the current value even on platforms that do not surface
+ATT_MTU changes via the {{maxwritewithoutresponsesizechanged}} event.
+3 octets are subtracted to account for the ATT Write Command header (1 octet
+opcode and 2 octet attribute handle), leaving the space available for the
+attribute value in a single PDU.
 </div>
 </div>
 
@@ -4409,8 +4413,9 @@ interface <a>participate in a tree</a>.
     {{BluetoothRemoteGATTCharacteristic/maxWriteWithoutResponseSize}}
     <a href="#mtu-change-events">changes</a>, for example after an
     [=Exchange MTU=] procedure renegotiates the ATT_MTU for the connection.
-    This event is best-effort: it is not guaranteed to fire on platforms
-    that do not surface ATT_MTU changes to the UA.
+    The UA fires this event when it observes such a change. Platforms that do
+    not surface ATT_MTU changes do not fire this event, but reading the
+    attribute still returns the current value.
   </dd>
 
   <dt>
@@ -4542,12 +4547,12 @@ the UA receives the result of an [=Exchange MTU=] procedure, the UA must
 perform the following steps for each <a>Characteristic</a>
 <var>characteristic</var> carried by that [=ATT Bearer=]:
 
-Note: These steps fire the {{maxwritewithoutresponsesizechanged}} event on a
-best-effort basis. Some platforms do not notify the UA when the ATT_MTU
-changes, in which case the event does not fire even though
-{{BluetoothRemoteGATTCharacteristic/maxWriteWithoutResponseSize}} may return a
-different value on a subsequent read. The event is therefore a hint to
-re-read the attribute, not an authoritative signal.
+Note: This event is a convenience notification. The
+{{BluetoothRemoteGATTCharacteristic/maxWriteWithoutResponseSize}} getter always
+reflects the current ATT_MTU when read, so reading it after a change returns the
+new value whether or not this event fires. Platforms that do not surface
+ATT_MTU changes to the UA never run these steps and so never fire the event,
+but a fresh read of the attribute still returns the current value.
 
 1. For each |bluetoothGlobal| whose [=Bluetooth tree=] contains a
     {{BluetoothRemoteGATTCharacteristic}} representing <var>characteristic</var>,


### PR DESCRIPTION
Hi folks 👋

I've been working on the Chromium implementation for exposing the
negotiated ATT MTU to web pages (crrev.com/c/7879985)

### What this adds

A new synchronous `maxWriteWithoutResponseSize` attribute on
`BluetoothRemoteGATTServer`:

```webidl
readonly attribute unsigned short maxWriteWithoutResponseSize;
```

It returns the largest byte sequence, in octets, that a single
`writeValueWithoutResponse()` can send without being rejected. It is
derived from the ATT_MTU negotiated for the connection to the device (the
smaller of the local Host's transmit ATT_MTU and the peer's receive
ATT_MTU), minus the 3-octet ATT Write Command header. When no MTU exchange
has happened it's `23 - 3 = 20` octets.

The value is backed by an internal slot on the server: it starts at 20, is
established when the connection is made, and is updated only when the UA
observes an ATT_MTU change -- at which point a
`maxwritewithoutresponsesizechanged` event fires at the
`BluetoothRemoteGATTServer` itself. The value never changes without the event
firing. The event deliberately doesn't carry the value; listeners read the
attribute, keeping a single source of truth. The
`onmaxwritewithoutresponsesizechanged` handler lives on the server.

### Why I want this

Today there's no way for a site to know how big a single write can be. The
practical pain is `writeValueWithoutResponse()`: if you hand it more than
`ATT_MTU - 3` bytes, the write either fails or gets silently chopped
depending on the platform, and the page has no way to tell ahead of time.
People end up hard-coding 20 (the old default payload) to be safe, which
leaves a lot of throughput on the table on modern devices that happily
negotiate 247+.

Exposing the max write size lets sites chunk their writes to fit a single
PDU and avoid unnecessary round trips. This has been asked for a few times
over the years (40265040 / 40686244 / 40163619 on the Chromium side).

### Design notes

- Returning `ATT_MTU - 3` (inspired by CoreBluetooth's
  `maximumWriteValueLengthForType:`) rather than the raw MTU means callers
  don't have to know to subtract the ATT Write Command header themselves.
- This lives on `BluetoothRemoteGATTServer` (device level) to match how
  the majority of platform APIs expose the value (CoreBluetooth, WinRT
  GattSession, Android). BlueZ tracks MTU per characteristic, so a
  BlueZ-based UA reads the property from any resolved characteristic (see
  discussion below).
- Platforms that never surface ATT_MTU changes to the UA simply never
  update the value after it is established, so the
  `maxwritewithoutresponsesizechanged` event never fires there; the event
  is best-effort by design.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hjanuschka/web-bluetooth/pull/672.html" title="Last updated on Aug 26, 2026, 9:52 PM UTC (9206831)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/672/2e451c1...hjanuschka:9206831.html" title="Last updated on Aug 26, 2026, 9:52 PM UTC (9206831)">Diff</a>